### PR TITLE
Convert all the generated files to PSR-2

### DIFF
--- a/src/stubs/migration.stub
+++ b/src/stubs/migration.stub
@@ -3,26 +3,25 @@
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class {{class}} extends Migration {
+class {{class}} extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        {{schema_up}}
+    }
 
-	/**
-	 * Run the migrations.
-	 *
-	 * @return void
-	 */
-	public function up()
-	{
-		{{schema_up}}
-	}
-
-	/**
-	 * Reverse the migrations.
-	 *
-	 * @return void
-	 */
-	public function down()
-	{
-		{{schema_down}}
-	}
-
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        {{schema_down}}
+    }
 }

--- a/src/stubs/pivot.stub
+++ b/src/stubs/pivot.stub
@@ -3,32 +3,30 @@
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class {{class}} extends Migration {
+class {{class}} extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('{{pivotTableName}}', function(Blueprint $table) {
+            $table->integer('{{columnOne}}_id')->unsigned()->index();
+            $table->foreign('{{columnOne}}_id')->references('id')->on('{{tableOne}}')->onDelete('cascade');
+            $table->integer('{{columnTwo}}_id')->unsigned()->index();
+            $table->foreign('{{columnTwo}}_id')->references('id')->on('{{tableTwo}}')->onDelete('cascade');
+        });
+    }
 
-	/**
-	 * Run the migrations.
-	 *
-	 * @return void
-	 */
-	public function up()
-	{
-		Schema::create('{{pivotTableName}}', function(Blueprint $table)
-		{
-			$table->integer('{{columnOne}}_id')->unsigned()->index();
-			$table->foreign('{{columnOne}}_id')->references('id')->on('{{tableOne}}')->onDelete('cascade');
-			$table->integer('{{columnTwo}}_id')->unsigned()->index();
-			$table->foreign('{{columnTwo}}_id')->references('id')->on('{{tableTwo}}')->onDelete('cascade');
-		});
-	}
-
-	/**
-	 * Reverse the migrations.
-	 *
-	 * @return void
-	 */
-	public function down()
-	{
-		Schema::drop('{{pivotTableName}}');
-	}
-
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('{{pivotTableName}}');
+    }
 }

--- a/src/stubs/seed.stub
+++ b/src/stubs/seed.stub
@@ -5,11 +5,10 @@ use Illuminate\Database\Seeder;
 // composer require laracasts/testdummy
 use Laracasts\TestDummy\Factory as TestDummy;
 
-class {{class}} extends Seeder {
-
+class {{class}} extends Seeder
+{
     public function run()
     {
         // TestDummy::times(20)->create('App\Post');
     }
-
 }


### PR DESCRIPTION
With the Laravel framework generators now using PSR-2 it would be nice if these were updated too.

This only updates the generated files and doesn't touch any of the package classes themselves.