### PR TITLE
Reformat package to be PSR-2

### DIFF
--- a/spec/Migrations/SyntaxBuilderSpec.php
+++ b/spec/Migrations/SyntaxBuilderSpec.php
@@ -15,11 +15,11 @@ class SyntaxBuilderSpec extends ObjectBehavior
     function it_creates_the_php_syntax_for_the_schema()
     {
         $schema = [[
-            "name"    => "email",
-            "type"    => "string",
+            "name" => "email",
+            "type" => "string",
             "arguments" => ["100"],
             "options" => [
-                "unique"   => true,
+                "unique" => true,
                 "nullable" => true,
                 "default" => '"foo@example.com"'
             ]
@@ -31,7 +31,8 @@ class SyntaxBuilderSpec extends ObjectBehavior
 
 }
 
-function getStub() {
+function getStub()
+{
     return <<<EOT
 Schema::create('{{table}}', function(Blueprint \$table) {
             \$table->increments('id');

--- a/src/Commands/MigrationMakeCommand.php
+++ b/src/Commands/MigrationMakeCommand.php
@@ -54,7 +54,7 @@ class MigrationMakeCommand extends Command
      *
      * @param Filesystem $files
      * @param NameParser $parser
-     * @param Composer   $composer
+     * @param Composer $composer
      */
     public function __construct(Filesystem $files, Composer $composer)
     {
@@ -84,9 +84,8 @@ class MigrationMakeCommand extends Command
     {
         $name = $this->argument('name');
 
-        if ($this->files->exists($path = $this->getPath($name)))
-        {
-            return $this->error($this->type.' already exists!');
+        if ($this->files->exists($path = $this->getPath($name))) {
+            return $this->error($this->type . ' already exists!');
         }
 
         $this->makeDirectory($path);
@@ -105,7 +104,7 @@ class MigrationMakeCommand extends Command
     {
         $modelPath = $this->getModelPath($this->getModelName());
 
-        if ($this->option('model') && ! $this->files->exists($modelPath)) {
+        if ($this->option('model') && !$this->files->exists($modelPath)) {
             $this->call('make:model', [
                 'name' => $this->getModelName(),
                 '--no-migration' => true
@@ -116,13 +115,12 @@ class MigrationMakeCommand extends Command
     /**
      * Build the directory for the class if necessary.
      *
-     * @param  string  $path
+     * @param  string $path
      * @return string
      */
     protected function makeDirectory($path)
     {
-        if ( ! $this->files->isDirectory(dirname($path)))
-        {
+        if (!$this->files->isDirectory(dirname($path))) {
             $this->files->makeDirectory(dirname($path), 0777, true, true);
         }
     }
@@ -135,20 +133,20 @@ class MigrationMakeCommand extends Command
      */
     protected function getPath($name)
     {
-        return './database/migrations/'.date('Y_m_d_His').'_'.$name.'.php';
+        return './database/migrations/' . date('Y_m_d_His') . '_' . $name . '.php';
     }
 
     /**
      * Get the destination class path.
      *
-     * @param  string  $name
+     * @param  string $name
      * @return string
      */
     protected function getModelPath($name)
     {
         $name = str_replace($this->getAppNamespace(), '', $name);
 
-        return $this->laravel['path'].'/'.str_replace('\\', '/', $name).'.php';
+        return $this->laravel['path'] . '/' . str_replace('\\', '/', $name) . '.php';
     }
 
     /**
@@ -158,7 +156,7 @@ class MigrationMakeCommand extends Command
      */
     protected function compileMigrationStub()
     {
-        $stub = $this->files->get(__DIR__.'/../stubs/migration.stub');
+        $stub = $this->files->get(__DIR__ . '/../stubs/migration.stub');
 
         $this->replaceClassName($stub)
             ->replaceSchema($stub)
@@ -250,5 +248,4 @@ class MigrationMakeCommand extends Command
             ['model', null, InputOption::VALUE_OPTIONAL, 'Want a model for this table?', true],
         ];
     }
-
 }

--- a/src/Commands/PivotMigrationMakeCommand.php
+++ b/src/Commands/PivotMigrationMakeCommand.php
@@ -8,7 +8,6 @@ use Symfony\Component\Console\Input\InputOption;
 
 class PivotMigrationMakeCommand extends GeneratorCommand
 {
-
     /**
      * The console command name.
      *
@@ -35,7 +34,9 @@ class PivotMigrationMakeCommand extends GeneratorCommand
      *
      * @return string
      */
-    protected function getNameInput() {}
+    protected function getNameInput()
+    {
+    }
 
     /**
      * Parse the name and format.
@@ -70,7 +71,7 @@ class PivotMigrationMakeCommand extends GeneratorCommand
     protected function getPath($name = null)
     {
         return './database/migrations/' . date('Y_m_d_His') .
-               '_create_' . $this->getPivotTableName() . '_pivot_table.php';
+        '_create_' . $this->getPivotTableName() . '_pivot_table.php';
     }
 
     /**
@@ -84,8 +85,8 @@ class PivotMigrationMakeCommand extends GeneratorCommand
         $stub = $this->files->get($this->getStub());
 
         return $this->replacePivotTableName($stub)
-                    ->replaceSchema($stub)
-                    ->replaceClass($stub, $name);
+            ->replaceSchema($stub)
+            ->replaceClass($stub, $name);
     }
 
     /**
@@ -159,5 +160,4 @@ class PivotMigrationMakeCommand extends GeneratorCommand
             ['tableTwo', InputArgument::REQUIRED, 'The name of the second table.']
         ];
     }
-
 }

--- a/src/Commands/SeedMakeCommand.php
+++ b/src/Commands/SeedMakeCommand.php
@@ -5,59 +5,58 @@ namespace Laracasts\Generators\Commands;
 use Illuminate\Console\GeneratorCommand;
 use Symfony\Component\Console\Input\InputOption;
 
-class SeedMakeCommand extends GeneratorCommand {
+class SeedMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:seed';
 
-	/**
-	 * The console command name.
-	 *
-	 * @var string
-	 */
-	protected $name = 'make:seed';
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new database seed class';
 
-	/**
-	 * The console command description.
-	 *
-	 * @var string
-	 */
-	protected $description = 'Create a new database seed class';
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Seed';
 
-	/**
-	 * The type of class being generated.
-	 *
-	 * @var string
-	 */
-	protected $type = 'Seed';
+    /**
+     * Parse the name and format according to the root namespace.
+     *
+     * @param  string $name
+     * @return string
+     */
+    protected function parseName($name)
+    {
+        return ucwords(camel_case($name)) . 'TableSeeder';
+    }
 
-	/**
-	 * Parse the name and format according to the root namespace.
-	 *
-	 * @param  string  $name
-	 * @return string
-	 */
-	protected function parseName($name)
-	{
-		return ucwords(camel_case($name)) . 'TableSeeder';
-	}
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__ . '/../stubs/seed.stub';
+    }
 
-	/**
-	 * Get the stub file for the generator.
-	 *
-	 * @return string
-	 */
-	protected function getStub()
-	{
-		return __DIR__.'/../stubs/seed.stub';
-	}
-
-	/**
-	 * Get the destination class path.
-	 *
-	 * @param  string  $name
-	 * @return string
-	 */
-	protected function getPath($name)
-	{
-		return './database/seeds/'.str_replace('\\', '/', $name).'.php';
-	}
-
+    /**
+     * Get the destination class path.
+     *
+     * @param  string $name
+     * @return string
+     */
+    protected function getPath($name)
+    {
+        return './database/seeds/' . str_replace('\\', '/', $name) . '.php';
+    }
 }

--- a/src/GeneratorException.php
+++ b/src/GeneratorException.php
@@ -2,13 +2,12 @@
 
 namespace Laracasts\Generators;
 
-class GeneratorException extends \Exception {
-
+class GeneratorException extends \Exception
+{
     /**
      * The exception description.
      *
      * @var string
      */
     protected $message = 'Could not determine what you are trying to do. Sorry! Check your migration name.';
-
 }

--- a/src/GeneratorsServiceProvider.php
+++ b/src/GeneratorsServiceProvider.php
@@ -4,64 +4,63 @@ namespace Laracasts\Generators;
 
 use Illuminate\Support\ServiceProvider;
 
-class GeneratorsServiceProvider extends ServiceProvider {
+class GeneratorsServiceProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap the application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        //
+    }
 
-	/**
-	 * Bootstrap the application services.
-	 *
-	 * @return void
-	 */
-	public function boot()
-	{
-		//
-	}
+    /**
+     * Register the application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->registerSeedGenerator();
+        $this->registerMigrationGenerator();
+        $this->registerPivotMigrationGenerator();
+    }
 
-	/**
-	 * Register the application services.
-	 *
-	 * @return void
-	 */
-	public function register()
-	{
-		$this->registerSeedGenerator();
-		$this->registerMigrationGenerator();
-		$this->registerPivotMigrationGenerator();
-	}
+    /**
+     * Register the make:seed generator.
+     */
+    private function registerSeedGenerator()
+    {
+        $this->app->singleton('command.laracasts.seed', function ($app) {
+            return $app['Laracasts\Generators\Commands\SeedMakeCommand'];
+        });
 
-	/**
-	 * Register the make:seed generator.
-	 */
-	private function registerSeedGenerator()
-	{
-		$this->app->singleton('command.laracasts.seed', function ($app) {
-			return $app['Laracasts\Generators\Commands\SeedMakeCommand'];
-		});
+        $this->commands('command.laracasts.seed');
+    }
 
-		$this->commands('command.laracasts.seed');
-	}
+    /**
+     * Register the make:migration generator.
+     */
+    private function registerMigrationGenerator()
+    {
+        $this->app->singleton('command.laracasts.migrate', function ($app) {
+            return $app['Laracasts\Generators\Commands\MigrationMakeCommand'];
+        });
 
-	/**
-	 * Register the make:migration generator.
-	 */
-	private function registerMigrationGenerator()
-	{
-		$this->app->singleton('command.laracasts.migrate', function ($app) {
-			return $app['Laracasts\Generators\Commands\MigrationMakeCommand'];
-		});
+        $this->commands('command.laracasts.migrate');
+    }
 
-		$this->commands('command.laracasts.migrate');
-	}
+    /**
+     * Register the make:pivot generator.
+     */
+    private function registerPivotMigrationGenerator()
+    {
+        $this->app->singleton('command.laracasts.migrate.pivot', function ($app) {
+            return $app['Laracasts\Generators\Commands\PivotMigrationMakeCommand'];
+        });
 
-	/**
-	 * Register the make:pivot generator.
-	 */
-	private function registerPivotMigrationGenerator()
-	{
-		$this->app->singleton('command.laracasts.migrate.pivot', function ($app) {
-			return $app['Laracasts\Generators\Commands\PivotMigrationMakeCommand'];
-		});
-
-		$this->commands('command.laracasts.migrate.pivot');
-	}
-
+        $this->commands('command.laracasts.migrate.pivot');
+    }
 }

--- a/src/Migrations/NameParser.php
+++ b/src/Migrations/NameParser.php
@@ -4,7 +4,6 @@ namespace Laracasts\Generators\Migrations;
 
 class NameParser
 {
-
     /**
      * Parse the migration name into something we can use.
      *
@@ -21,7 +20,7 @@ class NameParser
 
         return [
             'action' => $this->getAction($segments),
-            'table'  => $this->getTableName($segments)
+            'table' => $this->getTableName($segments)
         ];
     }
 
@@ -96,5 +95,4 @@ class NameParser
 
         return in_array($segment, $connectors);
     }
-
 }

--- a/src/Migrations/SchemaParser.php
+++ b/src/Migrations/SchemaParser.php
@@ -4,7 +4,6 @@ namespace Laracasts\Generators\Migrations;
 
 class SchemaParser
 {
-
     /**
      * The parsed schema.
      *
@@ -155,6 +154,5 @@ class SchemaParser
     {
         return array_key_exists('foreign', $segments['options']);
     }
-
 }
 

--- a/src/Migrations/SyntaxBuilder.php
+++ b/src/Migrations/SyntaxBuilder.php
@@ -6,7 +6,6 @@ use Laracasts\Generators\GeneratorException;
 
 class SyntaxBuilder
 {
-
     /**
      * A template to be inserted.
      *
@@ -17,8 +16,8 @@ class SyntaxBuilder
     /**
      * Create the PHP syntax for the given schema.
      *
-     * @param  array  $schema
-     * @param  array  $meta
+     * @param  array $schema
+     * @param  array $meta
      * @return string
      */
     public function create($schema, $meta)
@@ -33,7 +32,7 @@ class SyntaxBuilder
      * Create the schema for the "up" method.
      *
      * @param  string $schema
-     * @param  array  $meta
+     * @param  array $meta
      * @return string
      * @throws GeneratorException
      */
@@ -149,9 +148,9 @@ class SyntaxBuilder
      */
     private function constructSchema($schema, $direction = 'Add')
     {
-        if ( ! $schema) return '';
+        if (!$schema) return '';
 
-        $fields = array_map(function($field) use ($direction) {
+        $fields = array_map(function ($field) use ($direction) {
             $method = "{$direction}Column";
 
             return $this->$method($field);
@@ -196,5 +195,4 @@ class SyntaxBuilder
     {
         return sprintf("\$table->dropColumn('%s');", $field['name']);
     }
-
 }


### PR DESCRIPTION
Following on from the generator reformatting, this reformats the package itself.

There are a number of instances in the code where if statements start with `!` e.g.

```php
if ( ! $this->files->isDirectory(dirname($path)))
```

With the reformat this becomes

```php
if (!$this->files->isDirectory(dirname($path))) {
```

Which makes it much harder to see. Might it be worth reformatting this into something like this?

```php
if ($this->files->isDirectory(dirname($path)) === false) {
```