### PR TITLE
Only return unique field migrations

### DIFF
--- a/src/Migrations/SyntaxBuilder.php
+++ b/src/Migrations/SyntaxBuilder.php
@@ -156,6 +156,14 @@ class SyntaxBuilder
             return $this->$method($field);
         }, $schema);
 
+        /**
+         * remove any duplicated field definitions e.g when dropping a foreign
+         * column
+         *
+         * @see https://github.com/laracasts/Laravel-5-Generators-Extended/issues/21
+         */
+        $fields = array_unique($fields);
+
         return implode("\n" . str_repeat(' ', 12), $fields);
     }
 


### PR DESCRIPTION
This fixes #21 for me. There may be a nicer way but this is at least short and sweet :smile: In the example in #21 the `$fields` array originally was

```
array(2) {
  [0]=>
  string(28) "$table->dropColumn('phone');"
  [1]=>
  string(28) "$table->dropColumn('phone');"
}
```

So only returning unique items works fine. Is it possible that this might cause issues with other migrations?
