### PR TITLE
Path to generated migrations and seeds modified

### DIFF
--- a/src/Commands/MigrationMakeCommand.php
+++ b/src/Commands/MigrationMakeCommand.php
@@ -133,7 +133,7 @@ class MigrationMakeCommand extends Command
      */
     protected function getPath($name)
     {
-        return './database/migrations/' . date('Y_m_d_His') . '_' . $name . '.php';
+        return base_path() . '/database/migrations/' . date('Y_m_d_His') . '_' . $name . '.php';
     }
 
     /**

--- a/src/Commands/PivotMigrationMakeCommand.php
+++ b/src/Commands/PivotMigrationMakeCommand.php
@@ -70,7 +70,7 @@ class PivotMigrationMakeCommand extends GeneratorCommand
      */
     protected function getPath($name = null)
     {
-        return './database/migrations/' . date('Y_m_d_His') .
+        return base_path() . '/database/migrations/' . date('Y_m_d_His') .
         '_create_' . $this->getPivotTableName() . '_pivot_table.php';
     }
 

--- a/src/Commands/SeedMakeCommand.php
+++ b/src/Commands/SeedMakeCommand.php
@@ -57,6 +57,6 @@ class SeedMakeCommand extends GeneratorCommand
      */
     protected function getPath($name)
     {
-        return './database/seeds/' . str_replace('\\', '/', $name) . '.php';
+        return base_path() . '/database/seeds/' . str_replace('\\', '/', $name) . '.php';
     }
 }


### PR DESCRIPTION
Hi.

I modified path to generated migration and seed files in command. Old one caused problems when commands were called by Artisan::call() method. They were generated in /public/database/migrations folder instead of /database/migrations. 