### PR TITLE
Prevent a second migration from being created by the make:model command

### DIFF
--- a/src/Commands/MigrationMakeCommand.php
+++ b/src/Commands/MigrationMakeCommand.php
@@ -106,7 +106,8 @@ class MigrationMakeCommand extends Command
 
         if ($this->option('model') && !$this->files->exists($modelPath)) {
             $this->call('make:model', [
-                'name' => $this->getModelName()
+                'name' => $this->getModelName(),
+                '--no-migration' => 'true'
             ]);
         }
     }


### PR DESCRIPTION
The make:model command makes a migration with the model by default. Adding the --no-migration option to the make:model call prevents a second migration from being created, since this is called from the make:migration:schema command.

The true string doesn't really do anything. It's more of a placeholder and maybe helps readability.
