### PR TITLE
Fixed duplicate migration generation issue by passing --no-migration fixes #40

### DIFF
--- a/src/Commands/MigrationMakeCommand.php
+++ b/src/Commands/MigrationMakeCommand.php
@@ -106,7 +106,8 @@ class MigrationMakeCommand extends Command
 
         if ($this->option('model') && !$this->files->exists($modelPath)) {
             $this->call('make:model', [
-                'name' => $this->getModelName()
+                'name' => $this->getModelName(),
+                '--no-migration' => InputOption::VALUE_NONE
             ]);
         }
     }


### PR DESCRIPTION
Laravel 5's `artisan make:model ModelName` command creates a model as well as migration file for the given model, you need to specify `--no-migration` flag in order to skip the automatic migration generation by laravel.

Because this generator tool explicitly generates migration based on given schema, we don't need that extra migration file, so we can safely always pass `--no-migration` flag to skip generation of that extra file.

Which ultimately fixes #40.
