### PR TITLE
Replace 'model' option with 'no-model' switch

### DIFF
--- a/src/Commands/MigrationMakeCommand.php
+++ b/src/Commands/MigrationMakeCommand.php
@@ -104,7 +104,7 @@ class MigrationMakeCommand extends Command
     {
         $modelPath = $this->getModelPath($this->getModelName());
 
-        if ($this->option('model') && !$this->files->exists($modelPath)) {
+        if (!$this->option('no-model') && !$this->files->exists($modelPath)) {
             $this->call('make:model', [
                 'name' => $this->getModelName()
             ]);
@@ -244,7 +244,7 @@ class MigrationMakeCommand extends Command
     {
         return [
             ['schema', 's', InputOption::VALUE_OPTIONAL, 'Optional schema to be attached to the migration', null],
-            ['model', null, InputOption::VALUE_OPTIONAL, 'Want a model for this table?', true],
+            ['no-model', null, InputOption::VALUE_NONE, "Don't create a model for this table."],
         ];
     }
 }


### PR DESCRIPTION
Using `--model=false` doesn't work, and reading the text description
that would appear to be the way to toggle this switch, however, `false`
gets treated as a string. Using `--model=0` does work but isn't obvious.
This replaces `--model` option with `--no-model` switch instead. The
default is to create the model (as it currently does) but to disable
the creation of the model only `--no-model` needs to be supplied.
