### PR TITLE
Fix dummy class name make:migration:pivot

### DIFF
--- a/src/stubs/pivot.stub
+++ b/src/stubs/pivot.stub
@@ -3,7 +3,7 @@
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class {{class}} extends Migration
+class DummyClass extends Migration
 {
     /**
      * Run the migrations.

--- a/src/stubs/seed.stub
+++ b/src/stubs/seed.stub
@@ -5,7 +5,7 @@ use Illuminate\Database\Seeder;
 // composer require laracasts/testdummy
 use Laracasts\TestDummy\Factory as TestDummy;
 
-class {{class}} extends Seeder
+class DummyClass extends Seeder
 {
     public function run()
     {


### PR DESCRIPTION
Replace the {{class}} in .stub files by "DummyClass"