### PR TITLE
Add compound primary key make:migration:pivot

### DIFF
--- a/src/stubs/pivot.stub
+++ b/src/stubs/pivot.stub
@@ -17,6 +17,7 @@ class {{class}} extends Migration
             $table->foreign('{{columnOne}}_id')->references('id')->on('{{tableOne}}')->onDelete('cascade');
             $table->integer('{{columnTwo}}_id')->unsigned()->index();
             $table->foreign('{{columnTwo}}_id')->references('id')->on('{{tableTwo}}')->onDelete('cascade');
+            $table->primary(['{{columnOne}}_id', '{{columnTwo}}_id']);
         });
     }
 


### PR DESCRIPTION
Add
``` php
$table->primary(['{{columnOne}}_id', '{{columnTwo}}_id']);
```
to pivot.stub