### PR TITLE
Fixed pivot render class, added replaceClass method to command

### DIFF
--- a/src/Commands/PivotMigrationMakeCommand.php
+++ b/src/Commands/PivotMigrationMakeCommand.php
@@ -103,6 +103,20 @@ class PivotMigrationMakeCommand extends GeneratorCommand
     }
 
     /**
+    * Apply the name of the class to the stub
+    *
+    * @param string $stub
+    * @param string $name
+    * @return string
+    */
+    protected function replaceClass($stub, $name)
+    {
+        $nameClass = $this->parseName($name);
+
+        return str_replace('{{class}}',$nameClass, $stub);
+    }
+
+    /**
      * Apply the correct schema to the stub.
      *
      * @param  string $stub


### PR DESCRIPTION
Fixed issue with the render of class in stubs:

class {{class}} extends Migration

It was added a 'replaceClass' method in 'PivotMagrationMakeCommand.php' suitable for this generator.