### PR TITLE
Table names in plural form

### DIFF
--- a/src/Commands/MigrationMakeCommand.php
+++ b/src/Commands/MigrationMakeCommand.php
@@ -106,8 +106,7 @@ class MigrationMakeCommand extends Command
 
         if ($this->option('model') && !$this->files->exists($modelPath)) {
             $this->call('make:model', [
-                'name' => $this->getModelName(),
-                '--no-migration' => true
+                'name' => $this->getModelName()
             ]);
         }
     }

--- a/src/Commands/MigrationMakeCommand.php
+++ b/src/Commands/MigrationMakeCommand.php
@@ -28,7 +28,7 @@ class MigrationMakeCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Create a new migration class, and apply schema at the same time';
+    protected $description = 'Create a new migration class and apply schema at the same time';
 
     /**
      * The filesystem instance.

--- a/src/Commands/PivotMigrationMakeCommand.php
+++ b/src/Commands/PivotMigrationMakeCommand.php
@@ -139,8 +139,8 @@ class PivotMigrationMakeCommand extends GeneratorCommand
     protected function getSortedTableNames()
     {
         $tables = [
-            strtolower($this->argument('tableOne')),
-            strtolower($this->argument('tableTwo'))
+            str_plural(strtolower($this->argument('tableOne'))),
+            str_plural(strtolower($this->argument('tableTwo')))
         ];
 
         sort($tables);

--- a/src/stubs/pivot.stub
+++ b/src/stubs/pivot.stub
@@ -3,7 +3,7 @@
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class {{class}} extends Migration
+class DummyClass extends Migration
 {
     /**
      * Run the migrations.

--- a/src/stubs/pivot.stub
+++ b/src/stubs/pivot.stub
@@ -17,6 +17,7 @@ class DummyClass extends Migration
             $table->foreign('{{columnOne}}_id')->references('id')->on('{{tableOne}}')->onDelete('cascade');
             $table->integer('{{columnTwo}}_id')->unsigned()->index();
             $table->foreign('{{columnTwo}}_id')->references('id')->on('{{tableTwo}}')->onDelete('cascade');
+            $table->primary(['{{columnOne}}_id', '{{columnTwo}}_id']);
         });
     }
 

--- a/src/stubs/seed.stub
+++ b/src/stubs/seed.stub
@@ -5,7 +5,7 @@ use Illuminate\Database\Seeder;
 // composer require laracasts/testdummy
 use Laracasts\TestDummy\Factory as TestDummy;
 
-class {{class}} extends Seeder
+class DummyClass extends Seeder
 {
     public function run()
     {


### PR DESCRIPTION
On pivot tables references, table names must be in plural form.
Accept this please !