### PR TITLE
Created method for Change columns

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "laracasts/generators",
+  "name": "leoalmar/Laravel-5-Generators-Extended",
   "description": "Extend Laravel 5's generators.",
   "keywords": ["laravel", "generators"],
   "license": "MIT",

--- a/src/Commands/MigrationMakeCommand.php
+++ b/src/Commands/MigrationMakeCommand.php
@@ -205,7 +205,11 @@ class MigrationMakeCommand extends Command
             $schema = (new SchemaParser)->parse($schema);
         }
 
-        $schema = (new SyntaxBuilder)->create($schema, $this->meta);
+        if ($current = $this->option('current')) {
+            $current = (new SchemaParser)->parse($current);
+        }
+
+        $schema = (new SyntaxBuilder)->create($schema, $this->meta, $current);
 
         $stub = str_replace(['{{schema_up}}', '{{schema_down}}'], $schema, $stub);
 
@@ -243,6 +247,7 @@ class MigrationMakeCommand extends Command
     {
         return [
             ['schema', 's', InputOption::VALUE_OPTIONAL, 'Optional schema to be attached to the migration', null],
+            ['current', null, InputOption::VALUE_OPTIONAL, 'Required when the action is Change the migration', null],
             ['model', null, InputOption::VALUE_OPTIONAL, 'Want a model for this table?', true],
         ];
     }

--- a/src/Migrations/SyntaxBuilder.php
+++ b/src/Migrations/SyntaxBuilder.php
@@ -18,12 +18,13 @@ class SyntaxBuilder
      *
      * @param  array $schema
      * @param  array $meta
+     * @param  array $current
      * @return string
      */
-    public function create($schema, $meta)
+    public function create($schema, $meta, $current = null)
     {
         $up = $this->createSchemaForUpMethod($schema, $meta);
-        $down = $this->createSchemaForDownMethod($schema, $meta);
+        $down = $this->createSchemaForDownMethod($schema, $meta, $current);
 
         return compact('up', 'down');
     }
@@ -48,6 +49,12 @@ class SyntaxBuilder
             return $this->insert($fields)->into($this->getChangeSchemaWrapper());
         }
 
+        if ($meta['action'] == 'change') {
+            $fields = $this->constructSchema($schema, 'Change');
+       
+            return $this->insert($fields)->into($this->getChangeSchemaWrapper());
+        }
+
         if ($meta['action'] == 'remove') {
             $fields = $this->constructSchema($schema, 'Drop');
 
@@ -66,7 +73,7 @@ class SyntaxBuilder
      * @return string
      * @throws GeneratorException
      */
-    private function createSchemaForDownMethod($schema, $meta)
+    private function createSchemaForDownMethod($schema, $meta, $current)
     {
         // If the user created a table, then for the down
         // method, we should drop it.
@@ -78,6 +85,14 @@ class SyntaxBuilder
         // the down method, we should remove them.
         if ($meta['action'] == 'add') {
             $fields = $this->constructSchema($schema, 'Drop');
+
+            return $this->insert($fields)->into($this->getChangeSchemaWrapper());
+        }
+
+        // If the user changed columns from a table, then for the down
+        // method, we should change back it.
+        if ($meta['action'] == 'change') {
+            $fields = $this->constructSchema($current, 'Change');
 
             return $this->insert($fields)->into($this->getChangeSchemaWrapper());
         }
@@ -183,6 +198,17 @@ class SyntaxBuilder
         }
 
         return $syntax .= ';';
+    }
+
+    /**
+     * Construct the syntax to change a column.
+     *
+     * @param  string $field
+     * @return string
+     */
+    private function changeColumn($field)
+    {        
+        return str_replace(';','->change();',$this->addColumn($field));
     }
 
     /**


### PR DESCRIPTION
Used for change the configuration of the columns.
A new command option was added. The current param is used for make the rollback to the old type of the column.
Example:
php artisan make:migration:schema change_name_to_users_table --schema=“name:text” --current=“name:string”
