### PR TITLE
model file path not reflecting when make model

### DIFF
--- a/src/Commands/MigrationMakeCommand.php
+++ b/src/Commands/MigrationMakeCommand.php
@@ -102,15 +102,17 @@ class MigrationMakeCommand extends Command
      */
     protected function makeModel()
     {
-        $modelPath = $this->getModelPath($this->getModelName());
-
-        if ($this->option('model') && !$this->files->exists($modelPath)) {
-            $this->call('make:model', [
-                'name' => $this->getModelName()
-            ]);
+        if ($this->option('model')) {
+            $modelPath = $this->getModelPath($this->option('model'));
+            
+            if (!$this->files->exists($modelPath)) {
+                $this->call('make:model', [
+                    'name' => $modelPath
+                ]);
+            }
         }
     }
-
+    
     /**
      * Build the directory for the class if necessary.
      *
@@ -211,16 +213,6 @@ class MigrationMakeCommand extends Command
         $stub = str_replace(['{{schema_up}}', '{{schema_down}}'], $schema, $stub);
 
         return $this;
-    }
-
-    /**
-     * Get the class name for the Eloquent model generator.
-     *
-     * @return string
-     */
-    protected function getModelName()
-    {
-        return ucwords(str_singular(camel_case($this->meta['table'])));
     }
 
     /**


### PR DESCRIPTION
When running this `php artisan make:migration:schema create_food_beneficials_table --schema="id:integer:unsigned, food_id:integer:unsigned, title:string, description:text:nullable" --model="Models/FoodNutrition/FoodBeneficial"` it calls laravel `make:model` command but it creates model under `app` directory.

But when I run `php artisan make:model Models/FoodNutrition/FoodBeneficial` it creates correct model in correct directory inside `app/Models/FoodNutrition`.

I see in your https://github.com/laracasts/Laravel-5-Generators-Extended/blob/master/src/Commands/MigrationMakeCommand.php#L103 you are actually generating model name from meta table. Then what is the purpose for option `model` it's been only used as flag if the value of option `model` is `true` you are generating model. But it could have been used like laravel `make:model` command where you accept path not generate model name from meta table.

So my suggestion is you remove `getModelName` method(https://github.com/laracasts/Laravel-5-Generators-Extended/blob/master/src/Commands/MigrationMakeCommand.php#L219) & you rewrite this part(https://github.com/laracasts/Laravel-5-Generators-Extended/blob/master/src/Commands/MigrationMakeCommand.php#L101-L110) of code like this