### PR TITLE
Apply studly case to class name of pivot migration

### DIFF
--- a/src/Commands/PivotMigrationMakeCommand.php
+++ b/src/Commands/PivotMigrationMakeCommand.php
@@ -47,7 +47,7 @@ class PivotMigrationMakeCommand extends GeneratorCommand
     protected function parseName($name)
     {
         $tables = array_map('str_singular', $this->getSortedTableNames());
-        $name = implode('', array_map('ucwords', $tables));
+        $name = studly_case(implode('_', $tables));
 
         return "Create{$name}PivotTable";
     }


### PR DESCRIPTION
When table name supplied to "make:migration:pivot" command contained underscore,
it was inserted to name of generated migration class as well, which resulted
in "not found" error during migration.
