### PR TITLE
Added the "table" option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -203,6 +203,14 @@ Schema::create('posts', function(Blueprint $table) {
 
 Neato.
 
+You can also manually specify which table to use as a reference by using the "table" option like this: `logo_id:integer:foreign:table(images)`. You may have a logo image whose path is stored in an `images` table. This will give us:
+
+```
+$table->integer('logo_id');
+$table->foreign('logo_id')->references('id')->on('images');
+```
+
+
 ### Pivot Tables
 
 So you need a migration to setup a pivot table in your database? Easy. We can scaffold the whole class with a single command.

--- a/spec/Migrations/SchemaParserSpec.php
+++ b/spec/Migrations/SchemaParserSpec.php
@@ -56,4 +56,12 @@ class SchemaParserSpec extends ObjectBehavior
             ['name' => 'user_id', 'type' => 'foreign', 'arguments' => [], 'options' => ['references' => "'id'", 'on' => "'users'"]]
         ]);
     }
+
+    function it_parses_schema_fields_that_want_foreign_constraints_with_table()
+    {
+        $this->parse('logo_id:integer:foreign:table(images)')->shouldReturn([
+            ['name' => 'logo_id', 'type' => 'integer', 'arguments' => [], 'options' => []],
+            ['name' => 'logo_id', 'type' => 'foreign', 'arguments' => [], 'options' => ['references' => "'id'", 'on' => "'images'"]]
+        ]);
+    }
 }


### PR DESCRIPTION
Added the :table(<table_name>) option so you can manually specify the reference table for foreign keys.

For example you may want to set a logo for a company(`companies` table), which is an image from the `images` table. You can do that using the table option now:

`logo_id:integer:foreign:table(images)`

