### PR TITLE
Configurable stub locations

### DIFF
--- a/config/generators.php
+++ b/config/generators.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+    /**
+     * Override stub locations to use a custom stub
+     */
+    'stubs' => [
+        // 'migration'     => 'migration.stub',
+        // 'pivot'         => 'pivot.stub',
+        // 'schema-change' => 'schema-change.stub',
+        // 'schema-create' => 'schema-create.stub',
+        // 'seed'          => 'seed.stub',
+    ],
+];

--- a/src/Commands/MigrationMakeCommand.php
+++ b/src/Commands/MigrationMakeCommand.php
@@ -153,7 +153,7 @@ class MigrationMakeCommand extends Command
      */
     protected function compileMigrationStub()
     {
-        $stub = $this->files->get(__DIR__ . '/../stubs/migration.stub');
+        $stub = $this->files->get($this->getStub());
 
         $this->replaceClassName($stub)
             ->replaceSchema($stub)
@@ -245,4 +245,15 @@ class MigrationMakeCommand extends Command
             ['model', null, InputOption::VALUE_OPTIONAL, 'Want a model for this table?', true],
         ];
     }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return config('generators.stubs.migration', __DIR__ . '/../stubs/migration.stub');
+    }
+
 }

--- a/src/Commands/PivotMigrationMakeCommand.php
+++ b/src/Commands/PivotMigrationMakeCommand.php
@@ -59,7 +59,7 @@ class PivotMigrationMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__ . '/../stubs/pivot.stub';
+        return config('generators.stubs.pivot', __DIR__ . '/../stubs/pivot.stub');
     }
 
     /**

--- a/src/Commands/SeedMakeCommand.php
+++ b/src/Commands/SeedMakeCommand.php
@@ -46,7 +46,7 @@ class SeedMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__ . '/../stubs/seed.stub';
+        return config('generators.stubs.seed', __DIR__ . '/../stubs/seed.stub');
     }
 
     /**

--- a/src/GeneratorsServiceProvider.php
+++ b/src/GeneratorsServiceProvider.php
@@ -13,7 +13,9 @@ class GeneratorsServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        $this->publishes([
+            __DIR__ . '/../config/generators.php' => config_path('generators.php'),
+        ], 'config');
     }
 
     /**

--- a/src/GeneratorsServiceProvider.php
+++ b/src/GeneratorsServiceProvider.php
@@ -23,6 +23,7 @@ class GeneratorsServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->registerConfig();
         $this->registerSeedGenerator();
         $this->registerMigrationGenerator();
         $this->registerPivotMigrationGenerator();
@@ -62,5 +63,13 @@ class GeneratorsServiceProvider extends ServiceProvider
         });
 
         $this->commands('command.laracasts.migrate.pivot');
+    }
+
+    /**
+     * Register the default configuration.
+     */
+    private function registerConfig()
+    {
+        $this->mergeConfigFrom(__DIR__ . '/../config/generators.php', 'generators');
     }
 }

--- a/src/Migrations/SyntaxBuilder.php
+++ b/src/Migrations/SyntaxBuilder.php
@@ -126,7 +126,7 @@ class SyntaxBuilder
      */
     private function getCreateSchemaWrapper()
     {
-        return file_get_contents(__DIR__ . '/../stubs/schema-create.stub');
+        return file_get_contents(config('generators.stubs.schema-create', __DIR__ . '/../stubs/schema-create.stub'));
     }
 
     /**
@@ -136,7 +136,7 @@ class SyntaxBuilder
      */
     private function getChangeSchemaWrapper()
     {
-        return file_get_contents(__DIR__ . '/../stubs/schema-change.stub');
+        return file_get_contents(config('generators.stubs.schema-change', __DIR__ . '/../stubs/schema-change.stub'));
     }
 
     /**


### PR DESCRIPTION
Allow stub paths to be configurable so stubs can be customized.

Unfortunately, the tests are failing because the `config()` calls can't be resolved. Maybe someone with more test-foo can suggest how to get around that?