### PR TITLE
seed command improper class generate fix

### DIFF
--- a/src/stubs/seed.stub
+++ b/src/stubs/seed.stub
@@ -5,7 +5,7 @@ use Illuminate\Database\Seeder;
 // composer require laracasts/testdummy
 use Laracasts\TestDummy\Factory as TestDummy;
 
-class {{class}} extends Seeder
+class DummyClass extends Seeder
 {
     public function run()
     {


### PR DESCRIPTION
reference https://github.com/laracasts/Laravel-5-Generators-Extended/issues/51#issuecomment-267836492

Also check https://github.com/laravel/framework/blob/5.3/src/Illuminate/Console/GeneratorCommand.php#L195 here it replaces **`DummyClass`** with the **`class name`** like in other https://github.com/laravel/framework/blob/5.3/src/Illuminate/Database/Console/Seeds/stubs/seeder.stub#L5