### PR TITLE
Laravel 5.4 support

### DIFF
--- a/src/Commands/MigrationMakeCommand.php
+++ b/src/Commands/MigrationMakeCommand.php
@@ -2,7 +2,7 @@
 
 namespace Laracasts\Generators\Commands;
 
-use Illuminate\Console\AppNamespaceDetectorTrait;
+use Illuminate\Console\DetectsApplicationNamespace;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Laracasts\Generators\Migrations\NameParser;
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Input\InputArgument;
 
 class MigrationMakeCommand extends Command
 {
-    use AppNamespaceDetectorTrait;
+    use DetectsApplicationNamespace;
 
     /**
      * The console command name.

--- a/src/Commands/MigrationMakeCommand.php
+++ b/src/Commands/MigrationMakeCommand.php
@@ -2,8 +2,8 @@
 
 namespace Laracasts\Generators\Commands;
 
-use Illuminate\Console\DetectsApplicationNamespace;
 use Illuminate\Console\Command;
+use Illuminate\Container\Container;
 use Illuminate\Filesystem\Filesystem;
 use Laracasts\Generators\Migrations\NameParser;
 use Laracasts\Generators\Migrations\SchemaParser;
@@ -13,8 +13,6 @@ use Symfony\Component\Console\Input\InputArgument;
 
 class MigrationMakeCommand extends Command
 {
-    use DetectsApplicationNamespace;
-
     /**
      * The console command name.
      *
@@ -73,6 +71,16 @@ class MigrationMakeCommand extends Command
 
         $this->makeMigration();
         $this->makeModel();
+    }
+
+    /**
+     * Get the application namespace.
+     *
+     * @return string
+     */
+    protected function getAppNamespace()
+    {
+        return Container::getInstance()->getNamespace();
     }
 
     /**


### PR DESCRIPTION
When installing laracasts/generators on Laravel 5.4, it throws an error when running ```php artisan optimize```:

![screen shot 2017-01-24 at 17 13 09](https://cloud.githubusercontent.com/assets/1032474/22252905/69ee8216-e258-11e6-977e-a729fcd70c34.png)

Since [this class has been renamed from Laravel 5.3 to Laravel 5.4](https://github.com/laravel/framework/blob/5.4/src/Illuminate/Console/DetectsApplicationNamespace.php), my first thought was to just rename it to the 5.4 name. And I tried that. But it would make it:
- compatible with 5.4
- incompatible with 5.3

The alternative: forget about that trait and define ```MigrationMakeCommand::getAppNamespace()``` which does the same thing. This is what this PR does.

I'm not sure this is the best way to do it, but it's the only backwards-compatible way I thought of. Thoughts?

Cheers!