### PR TITLE
Changed make:migration:schema message to behave like make:migration

### DIFF
--- a/src/Commands/MigrationMakeCommand.php
+++ b/src/Commands/MigrationMakeCommand.php
@@ -98,7 +98,8 @@ class MigrationMakeCommand extends Command
 
         $this->files->put($path, $this->compileMigrationStub());
 
-        $this->info('Migration created successfully.');
+        $filename = pathinfo($path, PATHINFO_FILENAME);
+        $this->line("<info>Created Migration:</info> {$filename}");
 
         $this->composer->dumpAutoloads();
     }


### PR DESCRIPTION
The standard make:migration command prints the filename of the created migration when finished. I modified the make:migration:schema so it behaves the same way. 

I have found it very useful to be able to copy and paste the filename after creating a migration. 