### PR TITLE
Fixed issue with pivot table migration class name in 5.4

### DIFF
--- a/src/Commands/PivotMigrationMakeCommand.php
+++ b/src/Commands/PivotMigrationMakeCommand.php
@@ -36,6 +36,37 @@ class PivotMigrationMakeCommand extends GeneratorCommand
      */
     protected function getNameInput()
     {
+        return $this->parseName($this->getPivotTableName());
+    }
+    
+    /**
+     * Execute the console command.
+     *
+     * @return bool|null
+     */
+    public function fire()
+    {
+        $name = $this->getNameInput();
+
+        $path = $this->getPath($name);
+
+        // First we will check to see if the class already exists. If it does, we don't want
+        // to create the class and overwrite the user's code. So, we will bail out so the
+        // code is untouched. Otherwise, we will continue generating this class' files.
+        if ($this->alreadyExists($this->getNameInput())) {
+            $this->error($this->type.' already exists!');
+
+            return false;
+        }
+
+        // Next, we will generate the path to the location where this class' file should get
+        // written. Then, we will build the class and make the proper replacements on the
+        // stub files so that it gets the correctly formatted namespace and class name.
+        $this->makeDirectory($path);
+
+        $this->files->put($path, $this->buildClass($name));
+
+        $this->info($this->type.' created successfully.');
     }
 
     /**


### PR DESCRIPTION
Added a response to PivotMigrationMakeCommand::getNameInput() and overrrode PivotMigrationMakeCommand::fire() to correct pivot table migration class name being generated with the model namespace \App.