### PR TITLE
fire -> handle; laravel 5.5 support

### DIFF
--- a/src/Commands/MigrationMakeCommand.php
+++ b/src/Commands/MigrationMakeCommand.php
@@ -65,7 +65,7 @@ class MigrationMakeCommand extends Command
      *
      * @return mixed
      */
-    public function fire()
+    public function handle()
     {
         $this->meta = (new NameParser)->parse($this->argument('name'));
 


### PR DESCRIPTION
Would remove support for Laravel 5.0 I believe (if Laravel 5.0 is even supported still).

Without this fix, using the `make:migration:schema` command results in:

```
  [ReflectionException]
  Method Laracasts\Generators\Commands\MigrationMakeCommand::handle() does not exist
```