### PR TITLE
Curly bracket is not on a new line

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -228,8 +228,7 @@ class CreatePostTagPivotTable extends Migration {
 	 */
 	public function up()
 	{
-		Schema::create('post_tag', function(Blueprint $table)
-		{
+		Schema::create('post_tag', function(Blueprint $table) {
 			$table->integer('post_id')->unsigned()->index();
 			$table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
 			$table->integer('tag_id')->unsigned()->index();


### PR DESCRIPTION
Reading the stub file of pivot (and according to Laravel code format) the bracket after `Schema` should be on the same line. Not very important though...