### PR TITLE
Added Laravel 5.5 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,12 @@
     "psr-4": {
       "Laracasts\\Generators\\": "src/"
     }
+  },
+  "extra": {
+      "laravel": {
+          "providers": [
+              "Laracasts\\Generators\\GeneratorsServiceProvider"
+          ]
+      }
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,21 @@ L5 includes a bunch of generators out of the box, so this package only needs to 
 
 *With one or two more to come.*
 
-## Usage
+
+## Usage on Laravel 5.5
+
+### Step 1: Install Through Composer
+
+```
+composer require laracasts/generators --dev
+```
+
+### Step 2: Run Artisan!
+
+You're all set. Run `php artisan` from the console, and you'll see the new commands in the `make:*` namespace section.
+
+
+## Usage on Laravel 5.4 and 5.3
 
 ### Step 1: Install Through Composer
 

--- a/src/Commands/MigrationMakeCommand.php
+++ b/src/Commands/MigrationMakeCommand.php
@@ -61,6 +61,17 @@ class MigrationMakeCommand extends Command
     }
 
     /**
+     * Alias for the fire method.
+     *
+     * In Laravel 5.5 the fire() method has been renamed to handle().
+     * This alias provides support for both Laravel 5.4 and 5.5.
+     */
+    public function handle()
+    {
+        $this->fire();
+    }
+
+    /**
      * Execute the console command.
      *
      * @return mixed


### PR DESCRIPTION
Backwards compatible. Fully tested.

By adding the ```handle()``` alias to the ```fire()``` method:
- generators work on L5.5
- generators work on L5.4
- generators work on L5.3

By specifying the service provider in the composer.json file, on Laravel 5.5 projects:
- the installation is one less step;
- you no longer need to register the service provider depending on the environment, because Laravel does that for you;

What do you say, @JeffreyWay ? 2000+ [Backpack](https://backpackforlaravel.com/) developers will love you if you merge and tag this :-). Plus, this package will be ahead of the curve - same-day support for L5.5, that's really something :-)

Thanks, cheers! 

PS. Eaah... who am I kidding... They'd love you no matter what. We're all Laracasts addicts ;-)