### PR TITLE
Fix console command handle not found with Laravel 5.5

### DIFF
--- a/src/Commands/MigrationMakeCommand.php
+++ b/src/Commands/MigrationMakeCommand.php
@@ -74,6 +74,17 @@ class MigrationMakeCommand extends Command
     }
 
     /**
+     * Handle the console command.
+     * To support Laravel >= 5.5
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->fire();
+    }
+
+    /**
      * Get the application namespace.
      *
      * @return string


### PR DESCRIPTION
From Laravel 5.5 the support for fire is no longer used. Instead we should use handle method on our console commands.
When i run php artisan make:migration:schema on a project based on Laravel 5.5 i get the error message : ` Method Laracasts\Generators\Commands\MigrationMakeCommand::handle() does not exist`
