### PR TITLE
Add Option to remove primary id and timestamp column from migration

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -174,6 +174,8 @@ class RemoveUserIdFromPostsTable extends Migration {
 Here's a few other examples of commands that you might write:
 
 - `php artisan make:migration:schema create_posts_table`
+- `php artisan make:migration:schema create_posts_table --no-timestamp`
+- `php artisan make:migration:schema create_posts_table --no-primary-id`
 - `php artisan make:migration:schema create_posts_table --schema="title:string, body:text, excerpt:string:nullable"`
 - `php artisan make:migration:schema remove_excerpt_from_posts_table --schema="excerpt:string:nullable"`
 
@@ -186,6 +188,23 @@ php artisan make:migration:schema create_dogs_table --schema="name:string"
 ```
 
 You'll get a migration, populated with the schema...but you'll also get an Eloquent model at `app/Dog.php`. Naturally, you can opt out of this by adding the `--model=0` flag/option.
+
+#### Options 
+There are some options to help you.
+
+##### Remove timestamp column
+```
+php artisan make:migration:schema create_dogs_table --schema="name:string" --no-timestamp
+```
+
+This option remove $table->timestamps(); from the migration
+
+##### Remove primary id column
+```
+php artisan make:migration:schema create_dogs_table --schema="name:string" --no-index-id
+```
+
+This option remove $table->increments('id'); from the migration
 
 #### Foreign Constraints
 

--- a/src/Commands/MigrationMakeCommand.php
+++ b/src/Commands/MigrationMakeCommand.php
@@ -18,7 +18,7 @@ class MigrationMakeCommand extends Command
      *
      * @var string
      */
-    protected $name = 'make:migration:schema';
+    protected $name = 'make:migration:schema {--no-timestamp} {--no-primary-id}';
 
     /**
      * The console command description.
@@ -176,6 +176,8 @@ class MigrationMakeCommand extends Command
 
         $this->replaceClassName($stub)
             ->replaceSchema($stub)
+            ->setTimestampColumn($stub)
+            ->setIncrementColumn($stub)
             ->replaceTableName($stub);
 
         return $stub;
@@ -192,6 +194,36 @@ class MigrationMakeCommand extends Command
         $className = ucwords(camel_case($this->argument('name')));
 
         $stub = str_replace('{{class}}', $className, $stub);
+
+        return $this;
+    }
+
+    /**
+     * Set the timestamp column in the stub.
+     *
+     * @param  string $stub
+     * @return $this
+     */
+    protected function setTimestampColumn(&$stub)
+    {
+        $timestamp_field = array_key_exists('no-timestamp', $this->options()) ? '' : '$table->timestamps();';
+
+        $stub = str_replace('{{timestamp}}', $timestamp_field, $stub);
+
+        return $this;
+    }
+
+    /**
+     * Set the increment id column in the stub.
+     *
+     * @param  string $stub
+     * @return $this
+     */
+    protected function setIncrementColumn(&$stub)
+    {
+        $increment_field = array_key_exists('no-primary-id', $this->options()) ? '' : '$table->increments("id");';
+
+        $stub = str_replace('{{primary_id}}', $increment_field, $stub);
 
         return $this;
     }
@@ -262,6 +294,8 @@ class MigrationMakeCommand extends Command
         return [
             ['schema', 's', InputOption::VALUE_OPTIONAL, 'Optional schema to be attached to the migration', null],
             ['model', null, InputOption::VALUE_OPTIONAL, 'Want a model for this table?', true],
+            ['no-timestamp', null, InputOption::VALUE_OPTIONAL, 'Remove timestamp column field', null],
+            ['no-primary-id', null, InputOption::VALUE_OPTIONAL, 'Remove primary id column field', null],
         ];
     }
 }

--- a/src/stubs/schema-create.stub
+++ b/src/stubs/schema-create.stub
@@ -1,5 +1,5 @@
 Schema::create('{{table}}', function (Blueprint $table) {
-            $table->increments('id');
+            {{primary_id}}
             {{schema_up}}
-            $table->timestamps();
+            {{timestamp}}
         });


### PR DESCRIPTION
Hi, i add two options to remove primary id and timestamp column from migration if it's not necessary.