### PR TITLE
dumpAutoloads after creating Model [Fixes #157]

### DIFF
--- a/src/Commands/MigrationMakeCommand.php
+++ b/src/Commands/MigrationMakeCommand.php
@@ -82,6 +82,8 @@ class MigrationMakeCommand extends Command
 
         $this->makeMigration();
         $this->makeModel();
+        
+        $this->composer->dumpAutoloads();
     }
 
     /**
@@ -110,8 +112,6 @@ class MigrationMakeCommand extends Command
         $this->files->put($path, $this->compileMigrationStub());
 
         $this->info('Migration created successfully.');
-
-        $this->composer->dumpAutoloads();
     }
 
     /**


### PR DESCRIPTION
dump autoloads takes very long time in big app, so I suggest moving it after the model is created so developer can work on the created model sooner.