### PR TITLE
fix issue #144

### DIFF
--- a/src/stubs/pivot.stub
+++ b/src/stubs/pivot.stub
@@ -13,9 +13,9 @@ class {{class}} extends Migration
     public function up()
     {
         Schema::create('{{pivotTableName}}', function (Blueprint $table) {
-            $table->integer('{{columnOne}}_id')->unsigned()->index();
+            $table->unsignedBigInteger('{{columnOne}}_id')->index();
             $table->foreign('{{columnOne}}_id')->references('id')->on('{{tableOne}}')->onDelete('cascade');
-            $table->integer('{{columnTwo}}_id')->unsigned()->index();
+            $table->unsignedBigInteger('{{columnTwo}}_id')->index();
             $table->foreign('{{columnTwo}}_id')->references('id')->on('{{tableTwo}}')->onDelete('cascade');
             $table->primary(['{{columnOne}}_id', '{{columnTwo}}_id']);
         });


### PR DESCRIPTION
Laravel uses bigInteger instead of integer for ids now, so should the pivot table