### PR TITLE
Add support for Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "php": ">=5.4.0",
-    "illuminate/support": "^5.8|~6.0|~7.0"
+    "illuminate/support": "^5.8|~6.0|~7.0|~8.0"
   },
   "require-dev": {
     "phpspec/phpspec": "~2.1"


### PR DESCRIPTION
We aim to provide Laravel 8 support as a non-breaking change (aka patch update). But it might take a while to test all corner cases and work out any kinks of fully supporting Laravel 8.

If you're in a hurry to use Laravel 8... OR you want to help us test Generators on Laravel 8, please do:
```
composer require --dev laracasts/generators:"dev-add-support-for-laravel-8 as 1.1.99"
```

This will make sure your project uses this development branch. If you get an error similar to `Fatal error: Allowed memory size of 1610612736 bytes exhausted`, you can run the command below, but please also let us know you've encountered the error (reply here):
```
COMPOSER_MEMORY_LIMIT=-1 composer require --dev laracasts/generators:"dev-add-support-for-laravel-8 as 1.1.99"
```