### PR TITLE
fixed issue with array_map() expects parameter 1 to be a valid callback, class 'Str' not found in getSortedSingularTableNames

### DIFF
--- a/src/Commands/PivotMigrationMakeCommand.php
+++ b/src/Commands/PivotMigrationMakeCommand.php
@@ -170,7 +170,7 @@ class PivotMigrationMakeCommand extends GeneratorCommand
      */
     protected function getSortedSingularTableNames()
     {
-        $tables = array_map('Str::singular', $this->getTableNamesFromInput());
+        $tables = array_map(array(Str::class, 'singular'), $this->getTableNamesFromInput());
 
         sort($tables);
 


### PR DESCRIPTION
fixed `ErrorException : array_map() expects parameter 1 to be a valid callback, class 'Str' not found` in function getSortedSingularTableNames