### PR TITLE
Added missed Illuminate Schema facade

### DIFF
--- a/src/stubs/migration.stub
+++ b/src/stubs/migration.stub
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
 
 class {{class}} extends Migration
 {

--- a/src/stubs/pivot.stub
+++ b/src/stubs/pivot.stub
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
 
 class {{class}} extends Migration
 {


### PR DESCRIPTION
Hello and thank you for this package!

Migrations are generated without using "Illuminate\Support\Facades\Schema", which means you have to add it manually. It's a little annoying.

Now it's fixed :)

![image](https://github.com/laracasts/Laravel-5-Generators-Extended/assets/34450770/77ea6644-b539-4845-9aeb-37834613ee71)
![image](https://github.com/laracasts/Laravel-5-Generators-Extended/assets/34450770/e6299a61-d2a7-4b24-8c24-9c25c769b0f0)

